### PR TITLE
Ft cache nutritional values 137598759

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,11 @@ target/
 
 # IDE
 .idea/
+*.sublime-*
 
-# External Libraries 
+# External Libraries
 wger/core/static/bower_components
 node_modules
+
+# Mac OS
+.DS_Store

--- a/wger/nutrition/templates/plan/overview.html
+++ b/wger/nutrition/templates/plan/overview.html
@@ -14,7 +14,7 @@
             <h4 class="list-group-item-heading">{{plan}}</h4>
             <p class="list-group-item-text">
                 {{ plan.creation_date }} –
-                {{ plan.get_nutritional_values.total.energy|floatformat }} {% trans "kcal" %}
+                {{ plan.cached_total|floatformat }} {% trans "kcal" %}
             </p>
         </a>
     {% empty %}

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -29,6 +29,7 @@ from django.core.urlresolvers import reverse, reverse_lazy
 from django.contrib.auth.decorators import login_required
 from django.utils.translation import ugettext_lazy, ugettext as _
 from django.views.generic import DeleteView, UpdateView
+from django.core.cache import cache
 
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4, cm
@@ -49,6 +50,7 @@ from wger.utils.generic_views import WgerFormMixin, WgerDeleteMixin
 from wger.utils.helpers import check_token, make_token
 from wger.utils.pdf import styleSheet
 from wger.utils.language import load_language
+from wger.utils.cache import cache_mapper
 
 
 logger = logging.getLogger(__name__)
@@ -65,6 +67,17 @@ def overview(request):
     template_data.update(csrf(request))
 
     plans = NutritionPlan.objects.filter(user=request.user)
+    for plan in plans:
+        # Check if total calorie value in cache
+        # If not, add to cache
+        # If it exists, load value from cache
+        cached_total = cache.get(cache_mapper.get_nutrition_plan_key(int(plan.id)))
+        if not cached_total:
+            cache.set(cache_mapper.get_nutrition_plan_key(int(plan.id)), plan.get_nutritional_values()['total']['energy'])
+            plan.cached_total = cache.get(cache_mapper.get_nutrition_plan_key(int(plan.id)))
+        else:
+            plan.cached_total = cached_total
+
     template_data['plans'] = plans
 
     return render(request, 'plan/overview.html', template_data)

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -73,7 +73,8 @@ def overview(request):
         # If it exists, load value from cache
         cached_total = cache.get(cache_mapper.get_nutrition_plan_key(int(plan.id)))
         if not cached_total:
-            cache.set(cache_mapper.get_nutrition_plan_key(int(plan.id)), plan.get_nutritional_values()['total']['energy'])
+            cache.set(cache_mapper.get_nutrition_plan_key(int(plan.id)),
+                      plan.get_nutritional_values()['total']['energy'])
             plan.cached_total = cache.get(cache_mapper.get_nutrition_plan_key(int(plan.id)))
         else:
             plan.cached_total = cached_total

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -67,6 +67,7 @@ class CacheKeyMapper(object):
     INGREDIENT_CACHE_KEY = 'ingredient-{0}'
     WORKOUT_CANONICAL_REPRESENTATION = 'workout-canonical-representation-{0}'
     WORKOUT_LOG_LIST = 'workout-log-hash-{0}'
+    NUTRITION_PLAN_OVERVIEW = 'nutrition-plan-overview-{0}'
 
     def get_pk(self, param):
         '''
@@ -114,5 +115,9 @@ class CacheKeyMapper(object):
         Return the workout canonical representation
         '''
         return self.WORKOUT_LOG_LIST.format(hash_value)
+
+    def get_nutrition_plan_key(self, param):
+        return self.NUTRITION_PLAN_OVERVIEW.format(self.get_pk(param))
+
 
 cache_mapper = CacheKeyMapper()


### PR DESCRIPTION
#### What does this PR do?

Cache nutritional values so that we don't have to query the DB every time we load the nutritional plan overview page

#### Description of Task to be completed?

If a user has many plans (approx. more than 25), the overview renders slowly and too many DB-queries are fired just to calculate the total calories. Some caching of the values is probably the easiest solution, similar to the canonical_representation for workouts.

#### What are the relevant pivotal tracker stories?

137598759

