### PR TITLE
Bug update cache muscles #137598771

### DIFF
--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -92,7 +92,6 @@ class Muscle(models.Model):
         super(Muscle, self).delete(*args, **kwargs)
 
 
-
 @python_2_unicode_compatible
 class Equipment(models.Model):
     '''


### PR DESCRIPTION
#### What does this PR do?

Update the view of the exercise after the muscle in the exercise has been deleted

#### Description of Task to be completed?

It seems that after deleting a muscle, it keeps appearing in descriptions etc. This is probably due to the cache not being correctly reset.

#### What are the relevant pivotal tracker stories?

137598771

